### PR TITLE
Fix link name for browser extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Site Token: SinkCool
 We welcome your contributions and PRs.
 
 - [x] Browser Extension
-      - [Skin Tool](https://github.com/zhuzhuyule/sink-extension)
+      - [zhuzhuyule/sink-extension](https://github.com/zhuzhuyule/sink-extension)
 - [ ] Raycast Extension
 - [ ] Apple Shortcuts
 - [ ] Enhanced Link Management (with Cloudflare D1)


### PR DESCRIPTION
I don't think it's a _skin_ tool 😅 I used the username/reponame instead.